### PR TITLE
Switch to crates.io version of avr-device

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@
 [[package]]
 name = "arduino-uno"
 version = "0.1.0"
-source = "git+https://github.com/Rahix/avr-hal#f500e4e00cca6ee276d955ebf268ce9fd586a133"
+source = "git+https://github.com/Rahix/avr-hal#bafc9adef35769da1d993a84be323c699c95ff6c"
 dependencies = [
  "atmega328p-hal",
  "avr-hal-generic",
@@ -26,7 +26,7 @@ dependencies = [
 [[package]]
 name = "atmega328p-hal"
 version = "0.1.0"
-source = "git+https://github.com/Rahix/avr-hal#f500e4e00cca6ee276d955ebf268ce9fd586a133"
+source = "git+https://github.com/Rahix/avr-hal#bafc9adef35769da1d993a84be323c699c95ff6c"
 dependencies = [
  "avr-device",
  "avr-hal-generic",
@@ -35,16 +35,29 @@ dependencies = [
 [[package]]
 name = "avr-device"
 version = "0.1.0"
-source = "git+https://github.com/Rahix/avr-device#c314463726a2867b038b243f818b1f999c8ca22a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6576a465719d68f8391a2eb26cd3ae6b967aeeb18542e56454e54f0f8d1e4c1"
 dependencies = [
+ "avr-device-macros",
  "bare-metal",
  "vcell",
 ]
 
 [[package]]
+name = "avr-device-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c953188f9bdaa6c9af7d8045025b167aaa821982b428697dc4ddf5816c63917"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "avr-hal-generic"
 version = "0.1.0"
-source = "git+https://github.com/Rahix/avr-hal#f500e4e00cca6ee276d955ebf268ce9fd586a133"
+source = "git+https://github.com/Rahix/avr-hal#bafc9adef35769da1d993a84be323c699c95ff6c"
 dependencies = [
  "cfg-if",
  "embedded-hal",
@@ -186,9 +199,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "proc-macro-hack"
-version = "0.5.16"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
+checksum = "99c605b9a0adc77b7211c6b1f722dcb613d68d66859a44f3d485a6da332b0598"
 
 [[package]]
 name = "proc-macro-nested"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ panic-halt = "0.2.0"
 avr-hal-generic = { git = "https://github.com/Rahix/avr-hal" }
 arduino-uno = { git = "https://github.com/Rahix/avr-hal" }
 atmega328p-hal = { git = "https://github.com/Rahix/avr-hal" }
-avr-device = { git = "https://github.com/Rahix/avr-device" }
+avr-device = "0.1.0"
 pin-utils = "0.1.0"
 futures-util = { version = "0.3.5", default-features = false, features = ["async-await-macro"] }
 ufmt = "0.1.0"

--- a/README.md
+++ b/README.md
@@ -1,24 +1,10 @@
 # async-avr
 
 ## Initial installation
-
-```bash
-# rustfmt is not yet available for Rust since this was written, so we need to pass --force
-rustup install --force nightly-2020-07-24
-rustup install nightly
-rustup +nightly component add rustfmt
-rustup +nightly-2020-07-24 component add rust-src
-cargo install form svd2rust atdf2svd
-pip3 install --user pyyaml
-```
-
-In the future, when `rustfmt` is available for nightly builds after 2020-07-24:
+`async-avr` needs nightly rust:
 
 ```bash
 rustup install nightly
-rustup +nightly component add rustfmt rust-src
-cargo install form svd2rust atdf2svd
-pip3 install --user pyyaml
 ```
 
 ## Compiling and Running
@@ -26,10 +12,10 @@ pip3 install --user pyyaml
 We can compile by running
 
 ```bash
-cargo +nightly-2020-07-24 build -Z build-std=core --release --target avr-atmega328p.json
+cargo +nightly build -Z build-std=core --release --target avr-atmega328p.json
 ```
 
-(just `+nightly` when `rustfmt` is available for nightly builds after 2020-07-24). Then, to upload it to a device, enable "Show verbose output during: upload" in the Arduino IDE. Observe the build logs for an `avrdude` command—it should look something like:
+Then, to upload it to a device, enable "Show verbose output during: upload" in the Arduino IDE. Observe the build logs for an `avrdude` command—it should look something like:
 
 ```bash
 /path/to/.arduino15/packages/arduino/tools/avrdude/6.3.0-arduino17/bin/avrdude -C/path/to/.arduino15/packages/arduino/tools/avrdude/6.3.0-arduino17/etc/avrdude.conf -v -patmega328p -carduino -P/dev/ttyACM0 -b115200 -D -Uflash:w:/tmp/arduino_build_721874/Blink.ino.hex:i

--- a/examples/serial.rs
+++ b/examples/serial.rs
@@ -20,8 +20,8 @@ use arduino_uno::spi::{Settings, Spi};
 use async_avr::io::{AsyncReadExt, AsyncWriteExt};
 use async_avr::{block_on, AsyncSerial, AsyncSpi, Yield};
 
-#[no_mangle]
-pub extern "C" fn main() -> ! {
+#[arduino_uno::entry]
+fn main() -> ! {
     let dp = arduino_uno::Peripherals::take().unwrap();
 
     let mut pins = arduino_uno::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD);

--- a/examples/single-task.rs
+++ b/examples/single-task.rs
@@ -11,8 +11,8 @@ extern crate panic_halt;
 use async_avr::io::AsyncWriteExt;
 use async_avr::{block_on, AsyncSerial};
 
-#[no_mangle]
-pub extern "C" fn main() -> ! {
+#[arduino_uno::entry]
+fn main() -> ! {
     let dp = arduino_uno::Peripherals::take().unwrap();
 
     let mut pins = arduino_uno::Pins::new(dp.PORTB, dp.PORTC, dp.PORTD);


### PR DESCRIPTION
Hey,

I've published `avr-device` to crates.io and this removes all the build-dependency madness.  In this PR, I've updated your repo to reflect the changes.  You might want to update your blog-post as well :)

Disclaimer: I could only compile-test the change.  While this shouldn't break anything, I suggest, you quickly test for yourself if everything is still working ...