### PR TITLE
Pin `avr-hal` revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,7 +3,7 @@
 [[package]]
 name = "arduino-uno"
 version = "0.1.0"
-source = "git+https://github.com/Rahix/avr-hal#1e52121ff490ab44a0bfaa09e43fac608a8fef41"
+source = "git+https://github.com/Rahix/avr-hal?rev=7337cd76cd96f2d27701b137396d94a06d3a501d#7337cd76cd96f2d27701b137396d94a06d3a501d"
 dependencies = [
  "atmega328p-hal",
  "avr-hal-generic",
@@ -26,7 +26,7 @@ dependencies = [
 [[package]]
 name = "atmega328p-hal"
 version = "0.1.0"
-source = "git+https://github.com/Rahix/avr-hal#1e52121ff490ab44a0bfaa09e43fac608a8fef41"
+source = "git+https://github.com/Rahix/avr-hal?rev=7337cd76cd96f2d27701b137396d94a06d3a501d#7337cd76cd96f2d27701b137396d94a06d3a501d"
 dependencies = [
  "avr-device",
  "avr-hal-generic",
@@ -58,7 +58,7 @@ dependencies = [
 [[package]]
 name = "avr-hal-generic"
 version = "0.1.0"
-source = "git+https://github.com/Rahix/avr-hal#1e52121ff490ab44a0bfaa09e43fac608a8fef41"
+source = "git+https://github.com/Rahix/avr-hal?rev=7337cd76cd96f2d27701b137396d94a06d3a501d#7337cd76cd96f2d27701b137396d94a06d3a501d"
 dependencies = [
  "avr-device",
  "cfg-if",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,20 +34,21 @@ dependencies = [
 
 [[package]]
 name = "avr-device"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504d90bff86ad8ded797130e845915c7b42aa803e274309914ffbe02704e80e0"
+checksum = "4f90e107f4ecabe7158d79b8671e53f9fd342ec3d225bef00b94259652437b74"
 dependencies = [
  "avr-device-macros",
  "bare-metal",
+ "cfg-if",
  "vcell",
 ]
 
 [[package]]
 name = "avr-device-macros"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76e70e726ad355df910b74b50364336b0522414d51c2b35e66321fd44b3b21a0"
+checksum = "7173b28cd7dab80ad2a30269688de29a4b1e542923e805cffc4ef471a2e0407d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ panic-halt = "0.2.0"
 avr-hal-generic = { git = "https://github.com/Rahix/avr-hal" }
 arduino-uno = { git = "https://github.com/Rahix/avr-hal" }
 atmega328p-hal = { git = "https://github.com/Rahix/avr-hal" }
-avr-device = "0.2.1"
+avr-device = "0.2.2"
 pin-utils = "0.1.0"
 futures-util = { version = "0.3.5", default-features = false, features = ["async-await-macro"] }
 ufmt = "0.1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,9 @@ edition = "2018"
 
 [dependencies]
 panic-halt = "0.2.0"
-avr-hal-generic = { git = "https://github.com/Rahix/avr-hal" }
-arduino-uno = { git = "https://github.com/Rahix/avr-hal" }
-atmega328p-hal = { git = "https://github.com/Rahix/avr-hal" }
+avr-hal-generic = { git = "https://github.com/Rahix/avr-hal", rev = "7337cd76cd96f2d27701b137396d94a06d3a501d" }
+arduino-uno = { git = "https://github.com/Rahix/avr-hal", rev = "7337cd76cd96f2d27701b137396d94a06d3a501d" }
+atmega328p-hal = { git = "https://github.com/Rahix/avr-hal", rev = "7337cd76cd96f2d27701b137396d94a06d3a501d" }
 avr-device = "0.2.2"
 pin-utils = "0.1.0"
 futures-util = { version = "0.3.5", default-features = false, features = ["async-await-macro"] }


### PR DESCRIPTION
Hey,

I expect some breaking changes in avr-hal soon so I think it is a good idea to pin the git dependency to a known-working revision to prevent headaches in the future.  I've also updated the `avr-device` dependency explicitly to the latest version but I did not touch any other dependencies (running `cargo update` does show more possible updates).